### PR TITLE
Add prepublish command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npm run build && mocha --compilers coffee:coffee-script/register -R spec --ui bdd",
     "build": "coffee -o lib src/plugin.coffee",
+    "prepublish": "npm run build",
     "postinstall": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
This plugin really deserves its own npm package.

Added a `prepublish` script to deploy the intended result as a module.
I can't publish this myself, since it would appear I'm taking credit!

Documentation on `npm publish` is at https://docs.npmjs.com/cli/publish. If you haven't done this before, you'll need to register an account and use `npm adduser`.